### PR TITLE
Update datasets.py

### DIFF
--- a/OpenDFT/QHBench/QH9/datasets.py
+++ b/OpenDFT/QHBench/QH9/datasets.py
@@ -306,7 +306,7 @@ class QH9Dynamic(InMemoryDataset):
                             'num_nodes': row[2], 
                             'atoms': row[3], 
                             'pos': row[4], 
-                            'Ham': row[9]
+                            'Ham': row[5]
                         }
                         data_dict = pickle.dumps(ori_data_dict)
                         txn.put(ind.to_bytes(length=4, byteorder='big'), data_dict)
@@ -336,7 +336,7 @@ class QH9Dynamic(InMemoryDataset):
                             'num_nodes': row[2], 
                             'atoms': row[3], 
                             'pos': row[4], 
-                            'Ham': row[9]
+                            'Ham': row[5]
                         }
                         data_dict = pickle.dumps(ori_data_dict)
                         txn.put(ind.to_bytes(length=4, byteorder='big'), data_dict)


### PR DESCRIPTION
**Bug:** Running `python datasets.py` yields error on `row[9]`. 

**Fix:** If debug by inserting `print(len(row))` immediately before the error I get that `len(row)=6`. Changing `row[9]` to `row[5]` seems to fix the issue. 

**Further details:** I downloaded and extracted the data using 

```
#pip install gdown # this is a useful command line tool to download from google drive.
gdown 1CB1Hd4hdgwPq-ql25okB-xbuGJ9fswVM
gdown 1epys3ICQb7WF9azHUpk97fxo4V3IInjU
gdown 1Gatkvia6Ns5XWQEXFcAcn-cMMAftoCvX
gdown 18EY6PyeWp9737Fp2RVFQfz9VGhZNYpyk
gdown 1znGqJsjdrJW3ygYLCdObCZrtch2mKPJN
gdown 1PWUmrICoeisnbfqftkKzjKfk2yTjl98T
gdown 17bCyIgCRIHAUujXm2y5shlwgRKGDgxh7
gdown 1CgmpkDx3QIiQiSgkhDbUj9qk3sanlbHD

cat QH9Dynamic.zip.0* > QH9Dynamic.zip
unzip QH9Dynamic.zip
python datasets.py
```